### PR TITLE
Add split and join commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,5 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Delve debug files
-**/__debug_bin
-
 # Ignore vscode specific configs
 .vscode

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Whenever I worked with linux streams (especially string manipulation), I noticed
 Here are just some examples about how convoluted some of these are:
 
 ```
-# splitting a string by ":"
+# replacing ":" by "\n"
 echo -n "split:me" | sed 's/:/\n/g'
 echo -n "split:me" | tr ':' $'\n'
 
@@ -47,7 +47,7 @@ _* Want to uninstall? Just delete the binary and remove it from your `$PATH`._
 ## Using z
 z was invented to be intuitive. Here are some usage examples:
 ```
-# splitting a string by ":"
+# replacing ":" by "\n"
 echo -n "split:me" | z replace : \n
 
 # hashing 
@@ -65,11 +65,16 @@ echo -n "hexme" | z decode hex
 echo -n "lengthme" | z length
 ```
 
-Need to pipe multiple z's? There's a shorter way of doing it:
+Need to pipe multiple z's? Save yourself some typing:
 ```
-# get the length of an md5 hash
+# with pipes
+echo -n "hashme" | z hash md5 | z length
+
+# with z command chaining
 echo -n "hashme" | z hash md5 _ length
 ```
+
+_* (both have the exact same behavior)_
 
 ## Design principles
 z was designed with the following principles in mind

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 # z
-streams made easy
+pipes and streams made easy
 
 ## What is z?
 z is a Linux stream processor written in Go that aims to be easy and intuitive to work with.

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,21 @@
 - hash
 - replace
 - stream: consume in chunks until separator
-- split docs
 - join docs
 - usage section in readme 
   - split
   - join
   - streams
+- parameter treatment
+  - enclosing strings (":" = :)
+    - implementation
+    - tests
+    - docs
+  - patterns (regex)
+    - split
+    - replace
+    - implementation
+    - tests
+    - docs
 - environment configuration (zfile)
   - implicit joins

--- a/TODO.md
+++ b/TODO.md
@@ -8,3 +8,5 @@
   - split
   - join
   - streams
+- environment configuration (zfile)
+  - implicit joins

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,10 @@
+# TODO
+- hash
+- replace
+- stream: consume in chunks until separator
+- split docs
+- join docs
+- usage section in readme 
+  - split
+  - join
+  - streams

--- a/help/join.txt
+++ b/help/join.txt
@@ -6,19 +6,19 @@ summary:
     "join" commands are used anywhere after a "split" command.
         1. transform input contents into array with "split"
         2. map the array elements using other commands such as "hash", "replace" or "length"
-        3. join the array back into a string implicitly with "\n" or using "join"
+        3. join the array back into a string by concatenating its entries implicitly or by using "join"
 
-    split arrays with no closing join are implicitly joined with "\n"
+    split arrays with no closing join have their elements implicitly concatenated
 
 usage:
     z join [<delimiter>]
 
 parameters:
-    <delimiter> optional. default is "\n"
+    <delimiter> optional. default is "", which concatenates input
         the string to be used as delimiter.
 
 examples:
-    # get the lengths of all lines in a file and join them with "\n" (implicit join)
+    # get the lengths of all lines in a file and concatenate them (implicit join)
     z split _ length
 
     # get the lengths of all lines in a file and join them with ","

--- a/help/join.txt
+++ b/help/join.txt
@@ -1,0 +1,25 @@
+z join
+
+summary:
+    join an array of strings into a string
+
+    "join" commands are used anywhere after a "split" command.
+        1. transform input contents into array with "split"
+        2. map the array elements using other commands such as "hash", "replace" or "length"
+        3. join the array back into a string implicitly with "\n" or using "join"
+
+    split arrays with no closing join are implicitly joined with "\n"
+
+usage:
+    z join [<delimiter>]
+
+parameters:
+    <delimiter> optional. default is "\n"
+        the string to be used as delimiter.
+
+examples:
+    # get the lengths of all lines in a file and join them with "\n" (implicit join)
+    z split _ length
+
+    # get the lengths of all lines in a file and join them with ","
+    z split _ length _ join ,

--- a/help/replace.txt
+++ b/help/replace.txt
@@ -18,7 +18,7 @@ parameters:
         if range end is negative, counts in reverse order beginning from the last.
 
 examples:
-    # splitting by ":" (a.k.a replacing ":" by "\n")
+    # replacing ":" by "\n"
     z replace : \n
 
     # removing all ":"

--- a/help/split.txt
+++ b/help/split.txt
@@ -3,7 +3,7 @@ z split
 summary:
     split a string into an array of strings
 
-    usually, split is used together with other commands in the following order
+    "split" is used together with other commands in the following order
         1. transform input contents into array with "split"
         2. map the array elements using other commands such as "hash", "replace" or "length"
         3. join the array back into a string implicitly with "\n" or using "join"

--- a/help/split.txt
+++ b/help/split.txt
@@ -6,7 +6,7 @@ summary:
     "split" is used together with other commands in the following order
         1. transform input contents into array with "split"
         2. map the array elements using other commands such as "hash", "replace" or "length"
-        3. join the array back into a string implicitly with "\n" or using "join"
+        3. join the array back into a string by concatenating its entries implicitly or by using "join"
 
 usage:
     z split [<delimiter>]
@@ -22,10 +22,10 @@ examples:
     # splitting by whitespace character groups
     z split /(\s)+/
 
-    # get the length of all strings between ":"
+    # get the lengths of all strings between ":" and concatenate them
     z split : _ length
 
-    # get the md5 of every line in a file and join them by "\n"
+    # get the md5 of every line in a file and concatenate them
     z split _ hash md5
 
     # get the md5 the whole file (notice how the absence of "split" changes behavior)

--- a/help/split.txt
+++ b/help/split.txt
@@ -1,0 +1,35 @@
+z split
+
+summary:
+    split a string into an array of strings
+
+    usually, split is used together with other commands in the following order
+        1. transform input contents into array with "split"
+        2. map the array elements using other commands such as "hash", "replace" or "length"
+        3. join the array back into a string implicitly with "\n" or using "join"
+
+usage:
+    z split [<delimiter>]
+
+parameters:
+    <delimiter> optional. default is "\n"
+        the string or regular expression pattern to be used as delimiter. Patterns are enclosed with //.
+
+examples:
+    # splitting by ":"
+    z split :
+
+    # splitting by whitespace character groups
+    z split /(\s)+/
+
+    # get the length of all strings between ":"
+    z split : _ length
+
+    # get the md5 of every line in a file and join them by "\n"
+    z split _ hash md5
+
+    # get the md5 the whole file (notice how the absence of "split" changes behavior)
+    z hash md5
+
+    # get the lengths of all lines in a file and join them with ","
+    z split _ length _ join ,

--- a/help/z.txt
+++ b/help/z.txt
@@ -1,4 +1,4 @@
-z, streams made easy
+z, pipes and streams made easy
 
 usage:
     z <command> <...args> [_ <command> ...]

--- a/help/z.txt
+++ b/help/z.txt
@@ -12,11 +12,11 @@ commands:
     replace           find occurrences of a pattern/substring and replace them with a substring
 
 examples:
-    # splitting a string by ":"
-    z replace : \n
-
     # removing all ":" from a string
     z replace :
 
-    # geting the length of an md5 hash:
+    # getting the length of an md5 hash:
     z hash md5 _ length
+
+    # calculating md5 hash of things between ":"
+    z split : _ hash md5 _ join \n

--- a/help/z.txt
+++ b/help/z.txt
@@ -8,7 +8,9 @@ commands:
     help <command>    get help about a specific z command
 
     hash              hash a string according to an algorithm
+    join              join an array of strings into a string
     length            measure the length of a string
+    split             split a string into an array of strings
     replace           find occurrences of a pattern/substring and replace them with a substring
 
 examples:

--- a/internal/args.go
+++ b/internal/args.go
@@ -28,6 +28,8 @@ func parseCommand(args []string) commands.Command {
 		cmd = commands.ParseLength(args[1:])
 	case "help":
 		cmd = commands.ParseHelp(args[1:])
+	case "split":
+		cmd = commands.ParseSplit(args[1:])
 	}
 
 	return cmd

--- a/internal/args.go
+++ b/internal/args.go
@@ -30,6 +30,8 @@ func parseCommand(args []string) commands.Command {
 		cmd = commands.ParseHelp(args[1:])
 	case "split":
 		cmd = commands.ParseSplit(args[1:])
+	case "join":
+		cmd = commands.ParseJoin(args[1:])
 	}
 
 	return cmd

--- a/internal/args_test.go
+++ b/internal/args_test.go
@@ -13,6 +13,7 @@ var commandTypeMap = map[string]interface{}{
 
 	"help":   commands.Help{},
 	"length": commands.Length{},
+	"split":  commands.Split{},
 }
 
 func TestParseCommandTypes(t *testing.T) {

--- a/internal/args_test.go
+++ b/internal/args_test.go
@@ -14,6 +14,7 @@ var commandTypeMap = map[string]interface{}{
 	"help":   commands.Help{},
 	"length": commands.Length{},
 	"split":  commands.Split{},
+	"join":   commands.Join{},
 }
 
 func TestParseCommandTypes(t *testing.T) {

--- a/internal/commands/command.go
+++ b/internal/commands/command.go
@@ -4,5 +4,5 @@ type Command interface {
 	Err() error
 	Name() string
 	HelpFile() string
-	Execute(string) (string, error)
+	Execute([]byte) ([]byte, error)
 }

--- a/internal/commands/command.go
+++ b/internal/commands/command.go
@@ -4,5 +4,16 @@ type Command interface {
 	Err() error
 	Name() string
 	HelpFile() string
+}
+
+type MapCommand interface {
 	Execute([]byte) ([]byte, error)
+}
+
+type SplitCommand interface {
+	Execute([]byte) ([][]byte, error)
+}
+
+type JoinCommand interface {
+	Execute([][]byte) ([]byte, error)
 }

--- a/internal/commands/errors.go
+++ b/internal/commands/errors.go
@@ -18,3 +18,17 @@ type InvalidPipeErr struct {
 func (InvalidPipeErr) Error() string {
 	return "invalid pipe"
 }
+
+type ExtraJoinErr struct {
+}
+
+func (ExtraJoinErr) Error() string {
+	return "join operation without matching split"
+}
+
+type ExtraSplitErr struct {
+}
+
+func (ExtraSplitErr) Error() string {
+	return "split operation without matching join"
+}

--- a/internal/commands/help.go
+++ b/internal/commands/help.go
@@ -25,8 +25,8 @@ func (h Help) HelpFile() string {
 	return "z"
 }
 
-func (Help) Execute(in string) (string, error) {
-	return "", nil
+func (Help) Execute(in []byte) ([]byte, error) {
+	return nil, nil
 }
 
 func ParseHelp(args []string) Help {

--- a/internal/commands/invalid.go
+++ b/internal/commands/invalid.go
@@ -20,6 +20,6 @@ func (Invalid) HelpFile() string {
 	return "z"
 }
 
-func (Invalid) Execute(str string) (string, error) {
-	return "", nil
+func (Invalid) Execute(in []byte) ([]byte, error) {
+	return nil, nil
 }

--- a/internal/commands/join.go
+++ b/internal/commands/join.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"bytes"
+)
+
+type Join struct {
+	extraArg string
+
+	Separator []byte
+}
+
+func (j Join) Err() error {
+	if j.extraArg != "" {
+		return InvalidPositionalArgumentErr{
+			ArgumentName: j.extraArg,
+		}
+	}
+
+	return nil
+}
+
+func (Join) Name() string {
+	return "join"
+}
+
+func (Join) HelpFile() string {
+	return "join"
+}
+
+func (j Join) Execute(in [][]byte) ([]byte, error) {
+	return bytes.Join(in, j.Separator), nil
+}
+
+func ParseJoin(args []string) Join {
+	extraArg := ""
+	var sep []byte
+
+	switch len(args) {
+	case 0:
+		sep = []byte("")
+	case 1:
+		sep = []byte(args[0])
+	default:
+		extraArg = args[1]
+		sep = nil
+	}
+
+	return Join{
+		extraArg:  extraArg,
+		Separator: sep,
+	}
+}

--- a/internal/commands/length.go
+++ b/internal/commands/length.go
@@ -26,8 +26,8 @@ func (Length) HelpFile() string {
 	return "length"
 }
 
-func (Length) Execute(in string) (string, error) {
-	return fmt.Sprint(len(in)), nil
+func (Length) Execute(in []byte) ([]byte, error) {
+	return []byte(fmt.Sprint(len(in))), nil
 }
 
 func ParseLength(args []string) Length {

--- a/internal/commands/length_test.go
+++ b/internal/commands/length_test.go
@@ -1,15 +1,18 @@
 package commands
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestLengthExecute(t *testing.T) {
 	l := Length{}
-	result, err := l.Execute("1234")
+	result, err := l.Execute([]byte("1234"))
 	if err != nil {
 		t.Errorf("Length.Execute should never return error")
 	}
 
-	if result != "4" {
+	if !bytes.Equal(result, []byte("4")) {
 		t.Errorf("Length.Execute result is wrong")
 	}
 }

--- a/internal/commands/split.go
+++ b/internal/commands/split.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"bytes"
+)
+
+type Split struct {
+	extraArg string
+
+	Separator []byte
+}
+
+func (s Split) Err() error {
+	if s.extraArg != "" {
+		return InvalidPositionalArgumentErr{
+			ArgumentName: s.extraArg,
+		}
+	}
+
+	return nil
+}
+
+func (Split) Name() string {
+	return "split"
+}
+
+func (Split) HelpFile() string {
+	return "split"
+}
+
+func (s Split) Execute(in []byte) ([][]byte, error) {
+	return bytes.Split(in, s.Separator), nil
+}
+
+func ParseSplit(args []string) Split {
+	extraArg := ""
+	var sep []byte
+
+	switch len(args) {
+	case 0:
+		sep = []byte("\n")
+	case 1:
+		sep = []byte(args[0])
+	default:
+		extraArg = args[1]
+		sep = nil
+	}
+
+	return Split{
+		extraArg:  extraArg,
+		Separator: sep,
+	}
+}

--- a/internal/z.go
+++ b/internal/z.go
@@ -13,15 +13,82 @@ type Config struct {
 	Commands *list.List
 }
 
+func executeMap(bytes []byte, start *list.Element) ([]byte, *list.Element, error) {
+	var lastRan *list.Element
+	var err error
+
+	for e := start; e != nil; e = e.Next() {
+		switch e.Value.(type) {
+		case commands.MapCommand:
+			command := e.Value.(commands.MapCommand)
+			bytes, err = command.Execute(bytes)
+			if err != nil {
+				return nil, e, err
+			}
+		default:
+			return bytes, lastRan, nil
+		}
+
+		lastRan = e
+	}
+
+	return bytes, lastRan, nil
+}
+
+func executeSplit(bytes []byte, start *list.Element) ([]byte, *list.Element, error) {
+	var lastRan *list.Element
+
+	command := start.Value.(commands.SplitCommand)
+	splitBytes, err := command.Execute(bytes)
+	if err != nil {
+		return nil, start, err
+	}
+
+	for e := start; e != nil; e = e.Next() {
+		switch e.Value.(type) {
+		case commands.JoinCommand:
+			command := e.Value.(commands.JoinCommand)
+			bytes, err = command.Execute(splitBytes)
+			if err != nil {
+				return nil, e, err
+			}
+			return bytes, e, nil
+
+		case commands.MapCommand:
+			bytes, e, err = executeMap(bytes, e)
+			if err != nil {
+				return nil, e, err
+			}
+		}
+
+		lastRan = e
+	}
+
+	// finished without finding closing join
+	return nil, lastRan, commands.ExtraSplitErr{}
+}
+
 func (config Config) Execute(bytes []byte) ([]byte, error) {
 	var err error
+
 	for e := config.Commands.Front(); e != nil; e = e.Next() {
-		command := e.Value.(commands.Command)
-		bytes, err = command.Execute(bytes)
-		if err != nil {
-			return nil, err
+		switch e.Value.(type) {
+		case commands.JoinCommand:
+			return nil, commands.ExtraJoinErr{}
+		case commands.MapCommand:
+			bytes, e, err = executeMap(bytes, e)
+			if err != nil {
+				return nil, err
+			}
+		case commands.SplitCommand:
+			bytes, e, err = executeSplit(bytes, e)
+			if err != nil {
+				return nil, err
+			}
 		}
+
 	}
+
 	return bytes, nil
 }
 

--- a/internal/z.go
+++ b/internal/z.go
@@ -88,11 +88,13 @@ func executeSplit(bytes []byte, start *list.Element) ([]byte, *list.Element, err
 	// TODO: disallow implicit joins
 	// return nil, lastRan, commands.ExtraSplitErr{}
 
+	// in this case, return the last _known_ command that was ran
+	// (implicit joins are unknown to the config)
 	bytes, err = implicitJoin.Execute(splitBytes)
 	if err != nil {
-		return nil, nil, err
+		return nil, lastRan, err
 	}
-	return bytes, nil, nil
+	return bytes, lastRan, nil
 }
 
 func (config Config) Execute(bytes []byte) ([]byte, error) {

--- a/internal/z.go
+++ b/internal/z.go
@@ -13,6 +13,13 @@ type Config struct {
 	Commands *list.List
 }
 
+func NewConfig(err error, commands *list.List) Config {
+	return Config{
+		Err:      err,
+		Commands: commands,
+	}
+}
+
 func executeMap(bytes []byte, start *list.Element) ([]byte, *list.Element, error) {
 	var lastRan *list.Element
 	var err error
@@ -33,6 +40,10 @@ func executeMap(bytes []byte, start *list.Element) ([]byte, *list.Element, error
 	}
 
 	return bytes, lastRan, nil
+}
+
+var implicitJoin commands.JoinCommand = commands.Join{
+	Separator: []byte(""),
 }
 
 func executeSplit(bytes []byte, start *list.Element) ([]byte, *list.Element, error) {
@@ -74,8 +85,14 @@ func executeSplit(bytes []byte, start *list.Element) ([]byte, *list.Element, err
 		}
 	}
 
-	// finished without finding closing join
-	return nil, lastRan, commands.ExtraSplitErr{}
+	// TODO: disallow implicit joins
+	// return nil, lastRan, commands.ExtraSplitErr{}
+
+	bytes, err = implicitJoin.Execute(splitBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	return bytes, nil, nil
 }
 
 func (config Config) Execute(bytes []byte) ([]byte, error) {

--- a/internal/z_test.go
+++ b/internal/z_test.go
@@ -2,9 +2,56 @@ package internal
 
 import (
 	"bytes"
+	"container/list"
 	"strings"
 	"testing"
+
+	"github.com/serramatutu/z/internal/commands"
 )
+
+func TestExecuteMapOnlyMapCommands(t *testing.T) {
+	commandsList := list.New()
+	commandsList.PushBack(commands.Length{})
+	commandsList.PushBack(commands.Length{})
+
+	result, lastRan, err := executeMap([]byte("abcde"), commandsList.Front())
+	if err != nil {
+		t.Errorf("Unexpected error for executeMap")
+		return
+	}
+
+	expected := []byte("5")
+	if !bytes.Equal(result, []byte("1")) {
+		t.Errorf("Expected '%s' as executeMap output but got '%s'", expected, result)
+	}
+
+	if lastRan != commandsList.Back() {
+		t.Errorf("Expected executeMap to run until end of list")
+	}
+}
+
+func TestExecuteMapWithSplitCommand(t *testing.T) {
+	commandsList := list.New()
+	commandsList.PushBack(commands.Length{})
+	commandsList.PushBack(commands.Split{})
+	commandsList.PushBack(commands.Length{})
+
+	result, lastRan, err := executeMap([]byte("abcde"), commandsList.Front())
+	if err != nil {
+		t.Errorf("Unexpected error for executeMap")
+		return
+	}
+
+	expected := []byte("5")
+	if !bytes.Equal(result, []byte("5")) {
+		t.Errorf("Expected '%s' as executeMap output but got '%s'", expected, result)
+		return
+	}
+
+	if lastRan != commandsList.Front() {
+		t.Errorf("Expected executeMap to run until last map command")
+	}
+}
 
 func TestWriteLength(t *testing.T) {
 	args := []string{"z", "length"}

--- a/internal/z_test.go
+++ b/internal/z_test.go
@@ -17,7 +17,6 @@ func TestExecuteMapOnlyMapCommands(t *testing.T) {
 	result, lastRan, err := executeMap([]byte("abcde"), commandsList.Front())
 	if err != nil {
 		t.Errorf("Unexpected error for executeMap")
-		return
 	}
 
 	expected := []byte("5")
@@ -39,13 +38,11 @@ func TestExecuteMapWithSplitCommand(t *testing.T) {
 	result, lastRan, err := executeMap([]byte("abcde"), commandsList.Front())
 	if err != nil {
 		t.Errorf("Unexpected error for executeMap")
-		return
 	}
 
 	expected := []byte("5")
 	if !bytes.Equal(result, []byte("5")) {
 		t.Errorf("Expected '%s' as executeMap output but got '%s'", expected, result)
-		return
 	}
 
 	if lastRan != commandsList.Front() {

--- a/internal/z_test.go
+++ b/internal/z_test.go
@@ -8,14 +8,14 @@ import (
 
 func TestWriteLength(t *testing.T) {
 	args := []string{"z", "length"}
-	in := strings.NewReader("1234\n12345\n123456\n1234567")
+	in := strings.NewReader("1234\n\n")
 
 	var out bytes.Buffer
 	Z(args, in, &out)
 
-	expected := "5\n6\n7\n7"
+	expected := []byte("6")
 
-	if out.String() != expected {
+	if !bytes.Equal(out.Bytes(), []byte("6")) {
 		t.Errorf("Expected '%s' as Z output but got '%s'", expected, out.String())
 	}
 }

--- a/internal/z_test.go
+++ b/internal/z_test.go
@@ -78,16 +78,25 @@ func TestExecuteSplitNested(t *testing.T) {
 	}
 }
 
-func TestExecuteSplitMissingJoin(t *testing.T) {
+func TestExecuteSplitImplicitJoin(t *testing.T) {
 	commandsList := list.New()
 	commandsList.PushBack(commands.Split{
 		Separator: []byte(":"),
 	})
 	commandsList.PushBack(commands.Length{})
 
-	_, _, err := executeSplit([]byte("a:a:a"), commandsList.Front())
-	if err == nil {
-		t.Errorf("Expected 'ExtraSplitErr' when join is missing but got nil")
+	result, lastRan, err := executeSplit([]byte("a:a:a"), commandsList.Front())
+	if err != nil {
+		t.Errorf("Unexpected error for executeSplit")
+	}
+
+	expected := []byte("111")
+	if !bytes.Equal(result, expected) {
+		t.Errorf("Expected '%s' as executeSplit output but got '%s'", expected, result)
+	}
+
+	if lastRan != nil {
+		t.Errorf("Expected executeSplit to run implicit joins")
 	}
 }
 

--- a/internal/z_test.go
+++ b/internal/z_test.go
@@ -78,6 +78,19 @@ func TestExecuteSplitNested(t *testing.T) {
 	}
 }
 
+func TestExecuteSplitMissingJoin(t *testing.T) {
+	commandsList := list.New()
+	commandsList.PushBack(commands.Split{
+		Separator: []byte(":"),
+	})
+	commandsList.PushBack(commands.Length{})
+
+	_, _, err := executeSplit([]byte("a:a:a"), commandsList.Front())
+	if err == nil {
+		t.Errorf("Expected 'ExtraSplitErr' when join is missing but got nil")
+	}
+}
+
 func TestExecuteMapOnlyMapCommands(t *testing.T) {
 	commandsList := list.New()
 	commandsList.PushBack(commands.Length{})
@@ -116,6 +129,20 @@ func TestExecuteMapWithSplitCommand(t *testing.T) {
 
 	if lastRan != stop {
 		t.Errorf("Expected executeMap to stop at last available MapCommand")
+	}
+}
+
+func TestExecuteExtraJoin(t *testing.T) {
+	config := Config{
+		Err:      nil,
+		Commands: list.New(),
+	}
+	config.Commands.PushBack(commands.Length{})
+	config.Commands.PushBack(commands.Join{})
+
+	_, err := config.Execute([]byte("abcde"))
+	if err == nil {
+		t.Errorf("Expected 'ExtraJoinErr' when join is missing but got nil")
 	}
 }
 

--- a/internal/z_test.go
+++ b/internal/z_test.go
@@ -132,7 +132,7 @@ func TestExecuteMapWithSplitCommand(t *testing.T) {
 	}
 }
 
-func TestExecuteExtraJoin(t *testing.T) {
+func TestConfigExecuteExtraJoin(t *testing.T) {
 	config := Config{
 		Err:      nil,
 		Commands: list.New(),
@@ -143,6 +143,28 @@ func TestExecuteExtraJoin(t *testing.T) {
 	_, err := config.Execute([]byte("abcde"))
 	if err == nil {
 		t.Errorf("Expected 'ExtraJoinErr' when join is missing but got nil")
+	}
+}
+
+func TestConfigExecuteOk(t *testing.T) {
+	config := Config{
+		Err:      nil,
+		Commands: list.New(),
+	}
+	config.Commands.PushBack(commands.Split{
+		Separator: []byte(":"),
+	})
+	config.Commands.PushBack(commands.Length{})
+	config.Commands.PushBack(commands.Join{})
+
+	result, err := config.Execute([]byte("a:aa:a"))
+	if err != nil {
+		t.Errorf("Unexpected error for Config.Execute")
+	}
+
+	expected := []byte("121")
+	if !bytes.Equal(result, expected) {
+		t.Errorf("Expected '%s' as Config.Execute output but got '%s'", expected, result)
 	}
 }
 

--- a/internal/z_test.go
+++ b/internal/z_test.go
@@ -83,7 +83,7 @@ func TestExecuteSplitImplicitJoin(t *testing.T) {
 	commandsList.PushBack(commands.Split{
 		Separator: []byte(":"),
 	})
-	commandsList.PushBack(commands.Length{})
+	stop := commandsList.PushBack(commands.Length{})
 
 	result, lastRan, err := executeSplit([]byte("a:a:a"), commandsList.Front())
 	if err != nil {
@@ -95,8 +95,8 @@ func TestExecuteSplitImplicitJoin(t *testing.T) {
 		t.Errorf("Expected '%s' as executeSplit output but got '%s'", expected, result)
 	}
 
-	if lastRan != nil {
-		t.Errorf("Expected executeSplit to run implicit joins")
+	if lastRan != stop {
+		t.Errorf("Expected executeSplit to stop at last known command")
 	}
 }
 

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -1,1 +1,1 @@
-dlv debug ./cmd/z -l 127.0.0.1:2345 --headless -- $@
+dlv debug ./cmd/z -l 127.0.0.1:2345 --api-version 2 --output ./bin/debug --headless -- $@


### PR DESCRIPTION
Adds `z split` and `z join` commands, which allows strings to be split, mapped and then rejoined together. Implicit joins are concatenations.

Changed reading behavior, which now reads all to EOF instead of line by line