### PR TITLE
pipeline: fix ldflags injection (fixes #15)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,11 @@ before:
 builds:
   - main: ./cmd/z/main.go
     ldflags:
-      - -s -w -X 'config.Version={{.Version}}' -X 'config.Commit={{.Commit}}' -X 'config.Date={{.Date}}' -X 'config.BuiltBy="GoReleaser on Github Actions"' -X 'config.Repository="https://github.com/serramatutu/z/"'
+      - -X 'github.com/serramatutu/z/internal/config.Version={{.Version}}'
+      - -X 'github.com/serramatutu/z/internal/config.Commit={{.Commit}}'
+      - -X 'github.com/serramatutu/z/internal/config.Date={{.Date}}'
+      - -X 'github.com/serramatutu/z/internal/config.BuiltBy=GoReleaser on Github Actions'
+      - -X 'github.com/serramatutu/z/internal/config.Repository=https://github.com/serramatutu/z/'
     env:
       - CGO_ENABLED=0
     goos:

--- a/internal/config/build.go
+++ b/internal/config/build.go
@@ -2,8 +2,8 @@ package config
 
 // This will be replaced using ldargs
 var (
-	Version    = "dev"
-	Commit     = "none"
+	Version    = "unknown"
+	Commit     = "unknown"
 	Date       = "unknown"
 	BuiltBy    = "unknown"
 	Repository = "unknown"


### PR DESCRIPTION
Fixes goreleaser issue that would prevent it from properly injecting the
version, commit, date, builtby and repository variables into the
internal/packages directory.