### PR TITLE
refactor: help/version commands don't return error

### DIFF
--- a/internal/argparse/commands.go
+++ b/internal/argparse/commands.go
@@ -92,8 +92,5 @@ func ParseSplit(args []string) commands.Split {
 }
 
 func ParseVersion(args []string) commands.Version {
-	schema := []argument{}
-	// TODO: version schema
-	parseSchema(args, schema)
 	return commands.Version{}
 }

--- a/internal/argparse/parse.go
+++ b/internal/argparse/parse.go
@@ -14,18 +14,7 @@ type ArgumentErr struct {
 }
 
 func (err ArgumentErr) Error() string {
-	switch err.CommandName {
-	case "help":
-		return err.ErrText
-	case "version":
-		return err.ErrText
-	default:
-		runHelpText := fmt.Sprintf("run \"z help %s\" to learn more.\n", err.CommandName)
-		if err.ErrText != "" {
-			return fmt.Sprintf("error: %s\n%s", err.ErrText, runHelpText)
-		}
-		return runHelpText
-	}
+	return fmt.Sprintf("error: %s\nrun \"z help %s\" to learn more.\n", err.ErrText, err.CommandName)
 }
 
 func parseCommand(args []string) commands.Command {

--- a/internal/commands/command.go
+++ b/internal/commands/command.go
@@ -6,6 +6,10 @@ type Command interface {
 	HelpFile() string
 }
 
+type SingleExecCommand interface {
+	Execute() []byte
+}
+
 type MapCommand interface {
 	Execute([]byte) ([]byte, error)
 }

--- a/internal/commands/help.go
+++ b/internal/commands/help.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"errors"
-
 	"github.com/serramatutu/z/help"
 )
 
@@ -11,7 +9,7 @@ type Help struct {
 }
 
 func (h Help) Err() error {
-	return errors.New(help.Help[h.HelpFile()])
+	return nil
 }
 
 func (h Help) Name() string {
@@ -25,6 +23,6 @@ func (h Help) HelpFile() string {
 	return "z"
 }
 
-func (Help) Execute(in []byte) ([]byte, error) {
-	return nil, nil
+func (h Help) Execute() []byte {
+	return []byte(help.Help[h.HelpFile()])
 }

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -10,14 +10,7 @@ type Version struct {
 }
 
 func (Version) Err() error {
-	return fmt.Errorf(
-		"z %s\n  built at: %s\n  built by: %s\n  based on commit: %s\n  based on repository: %s",
-		config.Version,
-		config.Date,
-		config.BuiltBy,
-		config.Commit,
-		config.Repository,
-	)
+	return nil
 }
 
 func (Version) Name() string {
@@ -28,6 +21,13 @@ func (Version) HelpFile() string {
 	return "z"
 }
 
-func (Version) Execute(in []byte) ([]byte, error) {
-	return nil, nil
+func (Version) Execute() []byte {
+	return []byte(fmt.Sprintf(
+		"z %s\n  built at: %s\n  built by: %s\n  based on commit: %s\n  based on repository: %s\n",
+		config.Version,
+		config.Date,
+		config.BuiltBy,
+		config.Commit,
+		config.Repository,
+	))
 }

--- a/internal/z.go
+++ b/internal/z.go
@@ -117,6 +117,14 @@ func Z(zArgs []string, r io.Reader, w io.Writer) error {
 		return c.Err
 	}
 
+	// "help" and "version" commands need to exit before reading input
+	switch c.Commands.Front().Value.(type) {
+	case commands.SingleExecCommand:
+		cmd := c.Commands.Front().Value.(commands.SingleExecCommand)
+		w.Write(cmd.Execute())
+		return nil
+	}
+
 	contents, err := ioutil.ReadAll(r)
 	if err != nil {
 		return err


### PR DESCRIPTION
help/version commands used to return errors. There was an awkward
switch/case for checking for command names in ArgumentError.

This has been removed and now they implement the SingleExecCommand
interface, which executes a single command without reading from STDIN.
This interface is supposed to be used for commands that just return
something such as "version" and "help".