### PR TITLE
bug: backwards slash argument escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ echo -n "hexme" | z encode hex
 echo -n 6865786d65 | z decode hex
 
 # get the lengths of each line in a file
-z split \n _ length < myfile.txt
+z split "\n" _ length < myfile.txt
 ```
 
 Learn more about z with our [usage guide](https://serramatutu.github.io/z/docs/usage/).

--- a/cmd/z/main.go
+++ b/cmd/z/main.go
@@ -2,12 +2,19 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"github.com/serramatutu/z/internal"
 )
 
 func main() {
-	err := internal.Z(os.Args, os.Stdin, os.Stdout)
+	args := make([]string, len(os.Args))[:0]
+	for _, arg := range os.Args {
+		escapedArg := strings.Replace(arg, "\\n", "\n", -1)
+		args = append(args, escapedArg)
+	}
+
+	err := internal.Z(args, os.Stdin, os.Stdout)
 	if err != nil {
 		print(err.Error())
 		os.Exit(1)

--- a/docs/_docs/commands/replace.md
+++ b/docs/_docs/commands/replace.md
@@ -21,7 +21,7 @@ arguments:
       Zero range end means last match.
 examples: |
   # replacing ":" by "\n"
-  z replace : \n
+  z replace : "\n"
 
   # removing all ":"
   z replace : ""

--- a/docs/_docs/commands/split.md
+++ b/docs/_docs/commands/split.md
@@ -11,7 +11,7 @@ description: |
 arguments:
 - name: delimiter
   optional: true
-  default: "\n"
+  default: "\\n"
   type: pattern
   description: The regular expression pattern to be used as delimiter.
 examples: |

--- a/docs/_docs/usage/split-join.md
+++ b/docs/_docs/usage/split-join.md
@@ -14,7 +14,7 @@ Here are some examples:
 ```
 # getting the length of every line in infile.txt and writing that to outfile.txt's lines
 # (split's default delimiter is "\n")
-z split _ length _ join \n < infile.txt > outfile.txt
+z split _ length _ join "\n" < infile.txt > outfile.txt
 
 # print the md5 hashes of "a", "b" and "c", separated by ","
 echo -n "a:b:c" | z split : _ hash md5 _ join ,

--- a/help/replace.txt
+++ b/help/replace.txt
@@ -20,7 +20,7 @@ parameters:
 
 examples:
     # replacing ":" by "\n"
-    z replace : \n
+    z replace : "\n"
 
     # removing all ":"
     z replace : ""

--- a/help/z.txt
+++ b/help/z.txt
@@ -24,4 +24,4 @@ examples:
     z hash md5 _ length
 
     # calculating md5 hash of things between ":"
-    z split : _ hash md5 _ join \n
+    z split : _ hash md5 _ join "\n"


### PR DESCRIPTION
z was not escaping backward slash arguments, making "\n" arguments not work as expected